### PR TITLE
uptick npm package version to support node 4.x installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atmosphere.js",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "homepage": "https://github.com/Atmosphere/atmosphere-javascript",
   "description": "Atmosphere client for Node.js",
   "main": "index.js",


### PR DESCRIPTION
When installing Atmosphere with Node 4.x there is still a build error because v2.2.12 of package.json specifies contextify@0.8.10 as a dependency.

[This is the build error](https://github.com/brianmcd/contextify/issues/184) encountered when trying to install Atmosphere v2.2.12 with Node 4.x.

Support for Node 4.x (and a fix for this issue) [was recently merged in](https://github.com/Atmosphere/atmosphere.js-node/commit/fbba42e36854c7cdbf812f73c45a83a24e9d2035), but we must uptick the package version so that Node 4.x users can properly install via npm.
