### PR TITLE
ws: update dependency to version 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atmosphere.js",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "homepage": "https://github.com/Atmosphere/atmosphere-javascript",
   "description": "Atmosphere client for Node.js",
   "main": "index.js",
@@ -20,7 +20,7 @@
     "url": "https://github.com/Atmosphere/atmosphere-javascript/issues"
   },
   "dependencies": {
-    "ws": "0.8.0",
+    "ws": "1.0.1",
     "eventsource": "0.1.6",
     "xmlhttprequest": "1.8.0"
   },


### PR DESCRIPTION
The update to ws version 1.0.1 worked for my setup. Installed new version of atmosphere.js-node locally and tested my setup against the new version. Everything fine with the advantage of having no native dependency.
