### PR TITLE
Update eventsource to 2.0 to avoid url-parse authorization bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atmosphere.js",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "homepage": "https://github.com/Atmosphere/atmosphere-javascript",
   "description": "Atmosphere client for Node.js",
   "main": "index.js",
@@ -20,8 +20,8 @@
     "url": "https://github.com/Atmosphere/atmosphere-javascript/issues"
   },
   "dependencies": {
+    "eventsource": "^2.0.0",
     "ws": "^6.1.0",
-    "eventsource": "^1.0.7",
     "xmlhttprequest": "^1.8.0"
   },
   "browser": "./lib/browser.js",


### PR DESCRIPTION
Update to event source 2.0 to remove the dependency on urlparse to avoid npm audit vulnerability. (
https://github.com/advisories/GHSA-hgjh-723h-mx2j

Unsure if this should be marked as a major version or not as eventsource 2.0 has a requirement of node >= 12 
```
  "engines": {
    "node": ">=12.0.0"
  },
```

I have tested locally on my project without issue.